### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-#Skittles
+# Skittles
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Skittles-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/2076) [![Build Status](https://travis-ci.org/aashrairavooru/Skittles.svg)](https://travis-ci.org/aashrairavooru/Skittles)  [ ![Jcenter](https://img.shields.io/github/release/aashrairavooru/Skittles.svg?label=Jcenter) ](https://bintray.com/aashrairavooru/maven/Skittles/_latestVersion)
 [
 ![JitPackv](https://img.shields.io/github/release/aashrairavooru/Skittles.svg?label=JitPack)](https://jitpack.io/#aashrairavooru/Skittles/)
@@ -8,7 +8,7 @@ A simple,clean api for adding PushBullet style skittles to your app for more mat
 <img src="art/Skittle.gif" width=196 height=350/>
 <img src="art/TextSkittle.gif" width=196 height=350/>
 
-##Guide ([Sample](sample/src/main/java/snow/skittlessample/MainActivity.java))
+## Guide ([Sample](sample/src/main/java/snow/skittlessample/MainActivity.java))
 
 First some housekeeping code:
 
@@ -95,7 +95,7 @@ Here the `position` does not include the mainSkittle and starts from `0`
 
 You can now create your very own Skittle you just have to implement the [BaseSkittle](skittles/src/main/java/snow/skittles/BaseSkittle.java), check [TextSkittle](skittles/src/main/java/snow/skittles/TextSkittle.java) or [Skittle](skittles/src/main/java/snow/skittles/Skittle.java) for further reference
 
-##Snackbar Support
+## Snackbar Support
 <img src="art/Snackbar.gif" width=196 height=350/>
 <img src="art/SnackbarDismiss.gif" width=196 height=350/>
 
@@ -106,7 +106,7 @@ Snackbar.make(skittleLayout.getSkittleContainer(), "Skittle Pressed", Snackbar.L
 .show();
 ```
 
-##Gradle
+## Gradle
 ```groovy
 dependencies{
 compile 'com.rlj.library:skittles:4.1.1'
@@ -115,10 +115,10 @@ compile 'com.rlj.library:skittles:4.1.1'
 
 See the **[Sample](sample/src/main/java/snow/skittlessample/MainActivity.java)** and **[JavaDoc](http://aashrairavooru.github.io/Skittles/)** for further guidance
 
-##Upcoming
+## Upcoming
 + Better support for animations
 + Option for adding skittles by xml (inspired by Navigation View)
 
 
-#Taste the rainbow
+# Taste the rainbow
 ![Skittles](art/Taste the rainbow.jpg)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
